### PR TITLE
Fix handling of binary responses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ class MPDClient extends EventEmitter {
     this._config = config
     this._promiseQueue = []
     this._buf = ''
+    this._bufPos = 0
     this._idleevts = {}
     this._disconnecting
 
@@ -136,17 +137,33 @@ class MPDClient extends EventEmitter {
   _receive (data) {
     let matched
     this._buf += data
-    while ((matched = this._buf.match(MPD_SENTINEL)) !== null) {
-      let msg = this._buf.substring(0, matched.index)
-      let line = matched[0]
-      let code = matched[1]
-      let desc = matched[2]
+    let endPos = 0
 
-      code !== 'ACK'
-        ? this._resolve(msg || code) // if empty msg, send back OK
-        : this._reject(new MPDError(desc))
+    while ((endPos = this._buf.indexOf('\n', this._bufPos)) > -1) {
+      let line = this._buf.substring(this._bufPos, endPos)
 
-      this._buf = this._buf.substring(msg.length + line.length + 1)
+      if ((matched = line.match(MPD_SENTINEL)) !== null) {
+        let code = matched[1]
+        let desc = matched[2]
+
+        let msg = this._buf.substring(0, this._bufPos)
+
+        code !== 'ACK'
+          ? this._resolve(msg || code) // if empty msg, send back OK
+          : this._reject(new MPDError(desc))
+
+        this._buf = this._buf.substring(endPos + 1)
+        this._bufPos = 0
+        endPos = 0
+      } else {
+        // handle binary responses "as-is" by forwarding
+        // the buffer with the amount of expected bytes
+        if (line.substring(0, 7) === 'binary:') {
+          endPos += parseInt(line.substring(7));
+        }
+
+        this._bufPos = endPos + 1;
+      }
     }
   }
 


### PR DESCRIPTION
Hi,

first of all, thank you for your improvements on the MPD client lib! I have been using it in combination with your mpd-api lib for some time now, lately to retrieve and display the albumart from my MPD database, too.

That's when I found that some covers weren't retrieved properly, so I analyzed the problem. If they contained command completion sequences from MPD_SENTINEL (OK, ACK), the responses where cut short, and MPD finally dropping the connection.

The problem is the regex match for those sequences in the *whole* response text, even for binary data. So I had to change the way that you accumulate the response a bit.

As per protocol spec, each regular (text) response is a single line terminated by `\n`. So I accumulate the command response line by line, instead of matching for the MPD_SENTINEL beforehand. The MPD_SENTINEL will now only have to match a single line to check for command completion. That way you can properly handle [binary responses](https://mpd.readthedocs.io/en/stable/protocol.html#binary-responses) - by skipping the data by the announced amount of bytes from `binary: `. 

It was my first shot on the problem, but I haven't hit any more problems since then.

I tried to find a solution that required only minimal changes to your code and kept the coding style of your lib. So, if you are satisfied with those modifications, I'd appreciate if you'd have a look, and possibly merge and publish an updated version on npm. :nerd_face: 

Thanks!